### PR TITLE
Bugfix. When connection is closed or in closing - then no exception r…

### DIFF
--- a/aioari/client.py
+++ b/aioari/client.py
@@ -17,6 +17,10 @@ import logging
 log = logging.getLogger(__name__)
 
 
+class WSConnectionClosed(Exception):
+    pass
+
+
 class Client(object):
     """Async ARI Client object.
 
@@ -103,8 +107,8 @@ class Client(object):
             msg = await ws.receive()
             if msg is None:
                 return ## EOF
-            elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING}:
-                break
+            elif msg.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING}:
+                raise WSConnectionClosed("WS connection closed")
             elif msg.type != aiohttp.WSMsgType.TEXT:
                 log.warning("Unknown JSON message type: %s", repr(msg))
                 continue # ignore


### PR DESCRIPTION
If this exceptions happens on Asterisk side, there will be no exception on client code side and ari events subscription disappears silently for the main app:

[Jul 24 17:35:38] WARNING[42884] ari/ari_websockets.c: WebSocket poll error: Interrupted system call
[Jul 24 17:35:38] VERBOSE[42884] stasis/app.c: Deactivating Stasis app 'stasis_app'
[Jul 24 17:35:38] VERBOSE[42884] res_http_websocket.c: WebSocket connection from 'x.x.x.x:yyyyy' closed

We couldn't find the reason of this asterisk problem, but it happens sometimes without reason (tcp dump doesn't help).